### PR TITLE
chore(package): use correct identifier for license

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "contributors": [
     "jeromewu"
   ],
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/naptha/tesseract.js-core/issues"
   },


### PR DESCRIPTION
License checking tools use the [SPDX identifier](https://spdx.org/licenses/) to validate package licenses.

This will also bring the license value in line with https://github.com/naptha/tesseract.js