### PR TITLE
Change package.json license to valid spdx format

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "contributors": [
     "jeromewu"
   ],
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/naptha/tesseract.js-core/issues"
   },


### PR DESCRIPTION
We're using license-checker in our CI, but it returns Apache* for this package because the license is not valid spdx format.
So for now we're ignoring the error for this package, but that's not ideal.