### PR TITLE
Upgrade Emscripten to 4.0.15

### DIFF
--- a/build-scripts/build-openlibm.sh
+++ b/build-scripts/build-openlibm.sh
@@ -8,4 +8,4 @@ if [ $BUILD_CLEAN = 1 ]
 then
   $MAKE_CMD -C $LIB_PATH clean
 fi
-$MAKE_CMD -C $LIB_PATH prefix=$BUILD_DIR install-static -j$PROC
+$MAKE_CMD -C $LIB_PATH ARCH=wasm32 prefix=$BUILD_DIR install-static -j$PROC

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-EM_VERSION=3.1.38
+EM_VERSION=4.0.15
 
 # docker pull emscripten/emsdk:$EM_VERSION
 docker run \

--- a/javascript/glue.js
+++ b/javascript/glue.js
@@ -1333,7 +1333,7 @@ TessBaseAPI.prototype['GetStringVariable'] = TessBaseAPI.prototype.GetStringVari
 
 TessBaseAPI.prototype['Init'] = TessBaseAPI.prototype.Init = /** @suppress {undefinedVars, duplicate} */function(datapath, language, oem, configFilename) {
 
-  
+
   if (oem === undefined && configFilename !== undefined) oem = 3;
 
   var self = this.ptr;
@@ -1936,6 +1936,12 @@ Module['Pixa'] = Pixa;
     Module['PSM_COUNT'] = _emscripten_enum_PageSegMode_PSM_COUNT();
 
   }
-  if (runtimeInitialized) setupEnums();
-  else addOnInit(setupEnums);
+  if (Module['runtimeInitialized']) {
+    setupEnums();
+  } else {
+    var prev = Module['onRuntimeInitialized'];
+    Module['onRuntimeInitialized'] = prev
+      ? function () { prev.call(this); setupEnums(); }
+      : function () { setupEnums(); };
+  }
 })();


### PR DESCRIPTION
This PR upgrades Emscripten to 4.0.15 as a preparation step for enabling WASM Relaxed SIMD support in tesseract.js-core. 

Emscripten 4.0.15 includes support for 256-bit AVX intrinsic lowering to WebAssembly SIMD.

A related PR (https://github.com/Balearica/tesseract/pull/6) is provided to remove deprecated Emscripten flags in Tesseract, ensuring compatibility with newer versions.